### PR TITLE
Release: emergence-studio v0.7.2

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=studio
 pkg_origin=emergence
-pkg_version="0.7.1"
+pkg_version="0.7.2"
 pkg_maintainer="Chris Alfano <chris@jarv.us>"
 pkg_license=("MIT")
 pkg_deps=(

--- a/studio.sh
+++ b/studio.sh
@@ -132,6 +132,9 @@ init-user-config mysql-remote '
 
             [sites.default.holo]
             gitDir = \"${EMERGENCE_SITE_GIT_DIR:-${EMERGENCE_REPO}/.git}\"
+
+            [extensions.opcache.config]
+            validate_timestamps = false
         "
     fi
 


### PR DESCRIPTION
- feat: enable opcache timestamp validation in mutable studio sites